### PR TITLE
LA-#9157: file content-type UTF-16 encoding fix

### DIFF
--- a/src/TNEFDecoder/TNEFFile.php
+++ b/src/TNEFDecoder/TNEFFile.php
@@ -106,6 +106,9 @@ class TNEFFile extends TNEFFileBase
             if (!empty($mime_type[1])) 
                $type1 = $mime_type[1];
             $this->type = "$type0/$type1";
+            if ($is_unicode) {
+                $this->type = substr(iconv('utf-16', 'utf-8', $this->type), 0, -1);
+            }
             break;
 
          case TNEF_MAPI_ATTACH_EXTENSION:

--- a/src/TNEFDecoder/TNEFFileBase.php
+++ b/src/TNEFDecoder/TNEFFileBase.php
@@ -57,9 +57,6 @@ class TNEFFileBase
 
    function getType()
    {
-       if ($this->name_is_unicode) {
-           return substr(iconv('utf-16', 'utf-8', $this->type), 0, -1);
-       }
        return $this->type;
    }
 


### PR DESCRIPTION
Fixed UTF-16 encoding of attachment file mime type.
close QualityUnit/la-issues#9157