### PR TITLE
Improve decoding performance by reducing new string creation

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,25 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php"
-         backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true">
-
-    <testsuites>
-        <testsuite name="Project Test Suite">
-            <directory>test</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
-
-    <php>
-        <env name="APP_ENV" value="testing"/>
-    </php>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.2/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false" displayDetailsOnTestsThatTriggerWarnings="true">
+  <coverage/>
+  <testsuites>
+    <testsuite name="Project Test Suite">
+      <directory>test</directory>
+    </testsuite>
+  </testsuites>
+  <php>
+    <env name="APP_ENV" value="testing"/>
+  </php>
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/TNEFDecoder/TNEFBuffer.php
+++ b/src/TNEFDecoder/TNEFBuffer.php
@@ -1,0 +1,46 @@
+<?php namespace TNEFDecoder;
+
+/**
+  * SquirrelMail TNEF Decoder Plugin
+  *
+  * Copyright (c) 2010- Paul Lesniewski <paul@squirrelmail.org>
+  * Copyright (c) 2003  Bernd Wiegmann <bernd@wib-software.de>
+  * Copyright (c) 2002  Graham Norburys <gnorbury@bondcar.com>
+  *
+  * Licensed under the GNU GPL. For full terms see the file COPYING.
+  *
+  * @package plugins
+  * @subpackage tnef_decoder
+  *
+  */
+
+class TNEFBuffer
+{
+   private string $data;
+   private int $offset;
+
+   function __construct(string $data)
+   {
+      $this->data = $data;
+      $this->offset = 0;
+   }
+
+   function getBytes(int $numBytes): ?string
+   {
+      if ($this->getRemainingBytes() < $numBytes) {
+         $this->offset = strlen($this->data);
+         return null;
+      }
+
+      $this->offset += $numBytes;
+      return substr($this->data, $this->offset - $numBytes, $numBytes);
+   }
+
+   function getRemainingBytes(): int
+   {
+      return strlen($this->data) - $this->offset;
+   }
+}
+
+
+

--- a/src/TNEFDecoder/TNEFDate.php
+++ b/src/TNEFDecoder/TNEFDate.php
@@ -24,7 +24,7 @@ class TNEFDate
    var $minute;
    var $second;
 
-   function setTnefBuffer($buffer)
+   function setTnefBuffer(TNEFBuffer $buffer)
    {
       $this->year = tnef_geti16($buffer);
       $this->month = tnef_geti16($buffer);

--- a/src/TNEFDecoder/TNEFFile.php
+++ b/src/TNEFDecoder/TNEFFile.php
@@ -37,7 +37,6 @@ class TNEFFile extends TNEFFileBase
          // filename
          //
          case TNEF_AFILENAME:
-
             // strip path
             //
             if (($pos = strrpos($value, '/')) !== FALSE)
@@ -45,12 +44,13 @@ class TNEFFile extends TNEFFileBase
             else
                $this->name = $value;
 
+            // Strip trailing null bytes if present
+            $this->name = trim($this->name);
             break;
-
          // code page
          //
          case TNEF_AOEMCODEPAGE:
-            $this->code_page = tnef_geti16($value);
+            $this->code_page = tnef_geti16(new TNEFBuffer($value));
             break;
 
          // the attachment itself
@@ -67,11 +67,11 @@ class TNEFFile extends TNEFFileBase
 
          case TNEF_AATTACHCREATEDATE:
             $this->created = new TNEFDate();
-            $this->created->setTnefBuffer($value);
+            $this->created->setTnefBuffer(new TNEFBuffer($value));
 
          case TNEF_AATTACHMODDATE:
             $this->modified = new TNEFDate();
-            $this->modified->setTnefBuffer($value);
+            $this->modified->setTnefBuffer(new TNEFBuffer($value));
             break;
       }
    }
@@ -84,7 +84,6 @@ class TNEFFile extends TNEFFileBase
          // used in preference to AFILENAME value
          //
          case TNEF_MAPI_ATTACH_LONG_FILENAME:
-
             // strip path
             //
             if (($pos = strrpos($value, '/')) !== FALSE)
@@ -93,7 +92,6 @@ class TNEFFile extends TNEFFileBase
                $this->name = $value;
 
             if ($is_unicode) $this->name_is_unicode = TRUE;
-
             break;
 
          // Is this ever set, and what is format?
@@ -101,9 +99,9 @@ class TNEFFile extends TNEFFileBase
          case TNEF_MAPI_ATTACH_MIME_TAG:
             $type0 = $type1 = '';
             $mime_type = explode('/', $value, 2);
-            if (!empty($mime_type[0])) 
+            if (!empty($mime_type[0]))
                $type0 = $mime_type[0];
-            if (!empty($mime_type[1])) 
+            if (!empty($mime_type[1]))
                $type1 = $mime_type[1];
             $this->type = "$type0/$type1";
             if ($is_unicode) {

--- a/src/TNEFDecoder/TNEFFileBase.php
+++ b/src/TNEFDecoder/TNEFFileBase.php
@@ -25,7 +25,7 @@ class TNEFFileBase
    var $created;
    var $modified;
    var $debug;
- 
+
    function __construct($debug)
    {
       $this->name = 'Untitled';

--- a/src/TNEFDecoder/TNEFFileRTF.php
+++ b/src/TNEFDecoder/TNEFFileRTF.php
@@ -20,14 +20,14 @@ class TNEFFileRTF extends TNEFFileBase
    const MAX_DICT_SIZE = 4096;
    const INIT_DICT_SIZE = 207;
 
-   function __construct($debug, $buffer)
+   function __construct($debug, $data)
    {
       parent::__construct($debug);
       $this->type = "application/rtf";
       $this->name = "EmbeddedRTF.rtf";
       $this->debug = $debug;
 
-      $this->decode_crtf($buffer);
+      $this->decode_crtf(new TNEFBuffer($data));
    }
 
    function getSize()
@@ -35,7 +35,7 @@ class TNEFFileRTF extends TNEFFileBase
       return $this->size;
    }
 
-   function decode_crtf(&$buffer)
+   function decode_crtf(TNEFBuffer $buffer)
    {
       $size_compressed = tnef_geti32($buffer);
       $this->size = tnef_geti32($buffer);
@@ -61,8 +61,10 @@ class TNEFFileRTF extends TNEFFileBase
       }
    }
 
-   function uncompress(&$data)
+   function uncompress(TNEFBuffer $buffer)
    {
+      $data = tnef_getx($buffer->getRemainingBytes(), $buffer);
+
       $preload = "{\\rtf1\\ansi\\mac\\deff0\\deftab720{\\fonttbl;}{\\f0\\fnil \\froman \\fswiss \\fmodern \\fscript \\fdecor MS Sans SerifSymbolArialTimes New RomanCourier{\\colortbl\\red0\\green0\\blue0\n\r\\par \\pard\\plain\\f0\\fs20\\b\\i\\u\\tab\\tx";
       $length_preload = strlen($preload);
       $init_dict = [];
@@ -71,7 +73,7 @@ class TNEFFileRTF extends TNEFFileBase
       }
       $init_dict = array_merge($init_dict, array_fill(count($init_dict), self::MAX_DICT_SIZE - $length_preload, ' '));
       $write_offset = self::INIT_DICT_SIZE;
-      $output_buffer = '';
+      $output_buffer = [];
       $end = false;
       $in = 0;
       $l = strlen($data);
@@ -93,7 +95,7 @@ class TNEFFileRTF extends TNEFFileBase
                 for ($step = 0; $step < $actual_length; $step++) {
                     $read_offset = ($offset + $step) % self::MAX_DICT_SIZE;
                     $char = $init_dict[$read_offset];
-                    $output_buffer .= $char;
+                    $output_buffer[] = $char;
                   $init_dict[$write_offset] = $char;
                   $write_offset = ($write_offset + 1) % self::MAX_DICT_SIZE;
                }
@@ -102,13 +104,13 @@ class TNEFFileRTF extends TNEFFileBase
                     break;
                 }
                 $val = $data[$in++];
-                $output_buffer .= $val;
+                $output_buffer[] = $val;
                 $init_dict[$write_offset] = $val;
                 $write_offset = ($write_offset + 1) % self::MAX_DICT_SIZE;
             }
          }
       }
-      $this->content = $output_buffer;
+      $this->content = new TNEFBuffer(implode('', $output_buffer));
    }
 
 }

--- a/src/TNEFDecoder/TNEFMailinfo.php
+++ b/src/TNEFDecoder/TNEFMailinfo.php
@@ -60,6 +60,8 @@ class TNEFMailinfo
 
    function receiveTnefAttribute($attribute, $value, $length)
    {
+      $value = new TNEFBuffer($value);
+
       switch($attribute)
       {
          case TNEF_AOEMCODEPAGE:
@@ -67,7 +69,7 @@ class TNEFMailinfo
             break;
 
          case TNEF_ASUBJECT:
-            $this->subject = substr($value, 0, $length - 1);
+            $this->subject = tnef_getx($length - 1, $value);
             break;
 
          case TNEF_ADATERECEIVED:

--- a/src/TNEFDecoder/TNEFvCard.php
+++ b/src/TNEFDecoder/TNEFvCard.php
@@ -66,7 +66,7 @@ class TNEFvCard
    {
       if (empty($this->code_page))
          return $this->message_code_page;
-      else 
+      else
          return $this->code_page;
    }
 
@@ -158,7 +158,7 @@ class TNEFvCard
          // code page
          //
          case TNEF_AOEMCODEPAGE:
-            $this->code_page = tnef_geti16($value);
+            $this->code_page = tnef_geti16(new TNEFBuffer($value));
             break;
 
       }
@@ -238,7 +238,7 @@ class TNEFvCard
                tnef_log("Setting telefone '$telefone_key' to value '$value'");
          }
       }
-    
+
       return $rc;
    }
 
@@ -296,7 +296,7 @@ class TNEFvCard
                tnef_log("Setting homepage '$homepage_key' to value '$value'");
          }
       }
-    
+
       return $rc;
    }
 

--- a/src/TNEFDecoder/functions.php
+++ b/src/TNEFDecoder/functions.php
@@ -66,19 +66,25 @@ function extension_to_mime($extension)
   * TNEF decoding helper function
   *
   */
-function tnef_getx($size, &$buf)
+function tnef_getx($size, TNEFBuffer $buf)
 {
-   $value = NULL;
-   $len = strlen($buf);
-   if ($len >= $size)
-   {
-      $value = substr($buf, 0, $size);
-      $buf = substr_replace($buf, '', 0, $size);
+   return $buf->getBytes($size);
+}
+
+
+
+/**
+  * TNEF decoding helper function
+  *
+  */
+function tnef_geti8(TNEFBuffer $buf): int
+{
+   $bytes = $buf->getBytes(1, $buf);
+   if ($bytes === null) {
+        return null;
    }
-   else
-      substr_replace($buf, '', 0, $len);
 
-   return $value;
+   return ord($bytes[0]);
 }
 
 
@@ -87,18 +93,15 @@ function tnef_getx($size, &$buf)
   * TNEF decoding helper function
   *
   */
-function tnef_geti8(&$buf)
+function tnef_geti16(TNEFBuffer $buf): int
 {
-   $value = NULL;
-   $len = strlen($buf);
-   if ($len >= 1) {
-       $value = ord($buf[0]);
-       $buf = substr_replace($buf, '', 0, 1);
+   $bytes = $buf->getBytes(2, $buf);
+   if ($bytes === null) {
+        return null;
    }
-   else
-      substr_replace($buf, '', 0, $len);
 
-   return $value;
+   return ord($bytes[0])
+            + (ord($bytes[1]) << 8);
 }
 
 
@@ -107,38 +110,15 @@ function tnef_geti8(&$buf)
   * TNEF decoding helper function
   *
   */
-function tnef_geti16(&$buf)
+function tnef_geti32(TNEFBuffer $buf): int
 {
-    $value = NULL;
-    $len = strlen($buf);
-    if ($len >= 2) {
-        $value = ord($buf[0])
-            + (ord($buf[1]) << 8);
-        $buf = substr_replace($buf, '', 0, 2);
-    } else
-        substr_replace($buf, '', 0, $len);
+   $bytes = $buf->getBytes(4, $buf);
+   if ($bytes === null) {
+        return null;
+   }
 
-    return $value;
-}
-
-
-
-/**
-  * TNEF decoding helper function
-  *
-  */
-function tnef_geti32(&$buf)
-{
-    $value = NULL;
-    $len = strlen($buf);
-    if ($len >= 4) {
-        $value = ord($buf[0])
-            + (ord($buf[1]) << 8)
-            + (ord($buf[2]) << 16)
-            + (ord($buf[3]) << 24);
-        $buf = substr_replace($buf, '', 0, 4);
-    } else
-        substr_replace($buf, '', 0, $len);
-
-    return $value;
+   return ord($bytes[0])
+            + (ord($bytes[1]) << 8)
+            + (ord($bytes[2]) << 16)
+            + (ord($bytes[3]) << 24);
 }

--- a/test/TNEFAttachmentTest.php
+++ b/test/TNEFAttachmentTest.php
@@ -52,7 +52,7 @@ class TNEFAttachmentTest extends TestCase
       $this->assertEquals($withoutRtf, $withoutRtfdecoded);
    }
 
-   public function tnefFileProvider() {
+   public static function tnefFileProvider() {
       $tnefFiles = glob(dirname(__FILE__) . "/testfiles/*.tnef");
       $result = [];
       foreach ($tnefFiles as $tnefFile) {
@@ -69,11 +69,11 @@ class TNEFAttachmentTest extends TestCase
    }
 
    private function endsWithRtf($value) {
-      try {
-         return explode('.', $value)[1] != 'rtf';
-      } catch (Throwable $e) {
+      $arr = explode('.', $value);
+      if (count($arr) < 2) {
          return false;
       }
 
+      return $arr[1] !== 'rtf';
    }
 }


### PR DESCRIPTION
Rewriting strings constantly uses a lot of memory and slows decoding considerably. There was also a place where a large string was built incrementally. A test was broken as well (trailing null byte in a filename) and there were several test warnings in PHPUnit 10.2.

I've fixed the tests and done the minimal changes necessary to get rid of the slow string operations. I don't have benchmarks on the speed improvements but the timeouts we were seeing for mail delivery have disappeared so it is certainly faster and should also be much more resource efficient.