### PR TITLE
Fix/tnef content parsing

### DIFF
--- a/src/TNEFDecoder/TNEFAttachment.php
+++ b/src/TNEFDecoder/TNEFAttachment.php
@@ -348,7 +348,7 @@ class TNEFAttachment
              case TNEF_MAPI_ATTACH_DATA:
                  if ($this->debug)
                      tnef_log("MAPI Found nested attachment. Processing new one.");
-                 tnef_getx(16, $buffer); // skip the next 16 bytes (unknown data)
+                 $value = substr($value, 16); // skip the next 16 bytes (unknown data)
                  $att = new TNEFAttachment($this->debug, $this->validateChecksum);
                  $att->decodeTnef($value);
                  $this->attachments[] = $att;

--- a/src/TNEFDecoder/TNEFFileRTF.php
+++ b/src/TNEFDecoder/TNEFFileRTF.php
@@ -45,13 +45,15 @@ class TNEFFileRTF extends TNEFFileBase
       if ($this->debug)
          tnef_log("CRTF: size comp=$size_compressed, size=$this->size");
 
+      $data = tnef_getx($buffer->getRemainingBytes(), $buffer);
+
       switch ($magic) {
          case CRTF_COMPRESSED:
-            $this->uncompress($buffer);
+            $this->uncompress($data);
             break;
 
          case CRTF_UNCOMPRESSED:
-            $this->content = $buffer;
+            $this->content = $data;
             break;
 
          default:
@@ -61,10 +63,8 @@ class TNEFFileRTF extends TNEFFileBase
       }
    }
 
-   function uncompress(TNEFBuffer $buffer)
+   function uncompress($data)
    {
-      $data = tnef_getx($buffer->getRemainingBytes(), $buffer);
-
       $preload = "{\\rtf1\\ansi\\mac\\deff0\\deftab720{\\fonttbl;}{\\f0\\fnil \\froman \\fswiss \\fmodern \\fscript \\fdecor MS Sans SerifSymbolArialTimes New RomanCourier{\\colortbl\\red0\\green0\\blue0\n\r\\par \\pard\\plain\\f0\\fs20\\b\\i\\u\\tab\\tx";
       $length_preload = strlen($preload);
       $init_dict = [];
@@ -110,7 +110,7 @@ class TNEFFileRTF extends TNEFFileBase
             }
          }
       }
-      $this->content = new TNEFBuffer(implode('', $output_buffer));
+      $this->content = implode('', $output_buffer);
    }
 
 }


### PR DESCRIPTION
Unfortunately, certain things like nested files and content checking are not covered by the tests. Fixed two things discovered by our downstream testing. I think this should be it.